### PR TITLE
Raise minimum cmake version to 3.12.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ set(CMAKE_BUILD_TYPE
 ########################################################################
 # Project setup
 ########################################################################
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.12)
 project(gr-tenna CXX C)
 enable_testing()
 


### PR DESCRIPTION
This avoids warnings in cmake while maintaining compatibility with gnuradio cmake files.