### PR TITLE
Removing unused package. 

### DIFF
--- a/python/gotenna_packet/gotenna_packet.py
+++ b/python/gotenna_packet/gotenna_packet.py
@@ -26,7 +26,6 @@ import json
 import base64
 import csv
 import os
-import google
 from .proto import base_message_pb2
 from .proto import data_type_pb2
 from .proto import message_pb2


### PR DESCRIPTION
Removing unused package. Protobuf is imported as google.protobuf which only imports necessary protobuf and not the entire Google package